### PR TITLE
Update Plot.py

### DIFF
--- a/src/pywws/Plot.py
+++ b/src/pywws/Plot.py
@@ -650,7 +650,7 @@ class BasePlotter(object):
         of.close()
         self.graph.close()
         # run gnuplot on file
-        subprocess.check_call(['gnuplot', cmd_file])
+        subprocess.check_call(['/opt/bin/gnuplot', cmd_file])
         for file in self.tmp_files:
             os.unlink(file)
         return 0


### PR DESCRIPTION
(i have no solution to this fault, I just added my gnuplot path to solve the error.)
When I run the pywws-hourly script as root command line I get no errors, but when crond runs the script as root, I get an error.
script:
# !/bin/sh

/usr/bin/pywws-hourly /volume/weather/data/
error:
  File "/usr/lib/python2.7/site-packages/pywws/Plot.py", line 653, in DoPlot
    subprocess.check_call(['gnuplot', cmd_file])
  File "/usr/lib/python2.7/subprocess.py", line 535, in check_call
    retcode = call(_popenargs, *_kwargs)
  File "/usr/lib/python2.7/subprocess.py", line 522, in call
    return Popen(_popenargs, *_kwargs).wait()
  File "/usr/lib/python2.7/subprocess.py", line 710, in **init**
    errread, errwrite)
  File "/usr/lib/python2.7/subprocess.py", line 1327, in _execute_child
    raise child_exception
OSError: [Errno 2] No such file or directory

My guess is that it has something to do with how the system finds paths to execute the gnuplot command?
My system is synology (busybox) running pywws 14.06.1
