### PR TITLE
Added candlesticks plot as per my own request in issue #42

### DIFF
--- a/src/contributors/contributors.txt
+++ b/src/contributors/contributors.txt
@@ -10,6 +10,7 @@ Morten Høybye Frederiksen       morten@mfd-consult.dk
 Simon Josefsson                 simon@josefsson.org
 Matthew Hilton                  matthilton2005@gmail.com
 Sabine Tobolka			oe1yvw@gmail.com
+Markus Birth                    markus@birth-online.de
 
 Translators
 -----------

--- a/src/pywws/Plot.py
+++ b/src/pywws/Plot.py
@@ -444,6 +444,13 @@ computation is stored and made available to the next computation in
 the variable last_ycalc. This can be used with any data, but is most
 useful with rainfall: ``<ycalc>data['rain'] + last_ycalc</ycalc>``.
 
+A special case are plots with ``<style>candlesticks</style>`` or
+``<style>candlesticksw</style>`` which need 4 values in a specific
+order: ``<ycalc>(data['temp_out_min_ave'], data['temp_out_min_lo'],
+data['temp_out_max_hi'], data['temp_out_max_ave'])</ycalc>``. To add
+a median bar, use another candlesticks plot with
+``data['temp_out_ave']`` in all 4 fields.
+
 axes
 ^^^^
 
@@ -463,6 +470,12 @@ or ``<style>x</style>``. To select a line thickness 3 (for example)
 use: ``<style>line 3</style>``. The thickness of points can be set in
 a similar fashion. For complete control (for advanced users) a full
 gnuplot style can be set: ``<style>smooth unique lc 5 lw 3</style>``.
+
+For candlesticks plots you can specify line thickness as well, e.g.
+``<style>candlesticks 1.5</style>``. If you add whiskerbars, you can
+change the width of the whiskerbars with a second parameter, e.g.
+``<style>candlesticksw 2 0.5</style>`` would plot the whiskerbars with
+50% width of the candlesticks.
 
 colour
 ^^^^^^
@@ -904,8 +917,12 @@ set timefmt "%Y-%m-%dT%H:%M:%S"
                     else:
                         last_ycalc = subplot.last_ycalcs
                         value = eval(subplot.ycalc)
-                    subplot.dat.write('%s %g\n' % (idx.isoformat(), value))
-                    subplot.last_ycalcs = value
+                    if not isinstance(value, tuple):
+                        value = (value,)
+                    values = (idx.isoformat(),) + value
+                    vformat = '%s' + (' %g' * len(value)) + '\n'
+                    subplot.dat.write(vformat % values)
+                    subplot.last_ycalcs = value[0]
                 except TypeError:
                     if not subplot.cummulative:
                         subplot.dat.write('%s ?\n' % (idx.isoformat()))
@@ -925,12 +942,22 @@ set timefmt "%Y-%m-%dT%H:%M:%S"
             style = subplot.subplot.get_value(
                 'style', 'smooth unique lc %s lw 1' % (colour))
             words = style.split()
-            if len(words) > 1 and words[0] in ('+', 'x', 'line'):
+            if len(words) > 1 and words[0] in ('+', 'x', 'line', 'candlesticks', 'candlesticksw'):
                 width = float(words[1])
             else:
                 width = 1
+            if len(words) > 2 and words[0] in ('candlesticksw'):
+                whiskerwidth = float(words[2])
+            else:
+                whiskerwidth = 1
+            whiskerbars = ''
             if style == 'box':
                 style = 'lc %s lw 0 with boxes' % (colour)
+            elif words[0] == 'candlesticks':
+                style = 'lc %s lw %g with candlesticks' % (colour, width)
+            elif words[0] == 'candlesticksw':
+                style = 'lc %s lw %g with candlesticks' % (colour, width)
+                whiskerbars = ' whiskerbars %g' % (whiskerwidth)
             elif words[0] == '+':
                 style = 'lc %s lw %g pt 1 with points' % (colour, width)
             elif words[0] == 'x':
@@ -939,8 +966,9 @@ set timefmt "%Y-%m-%dT%H:%M:%S"
                 style = 'smooth unique lc %s lw %g' % (colour, width)
             axes = subplot.subplot.get_value('axes', 'x1y1')
             title = subplot.subplot.get_value('title', '')
-            result += u' "%s" using 1:2 axes %s %s title "%s"' % (
-                subplot.dat_file, axes, style, title)
+            using = ':'.join(str(x) for x in range(1, len(values)+1))
+            result += u' "%s" using %s axes %s %s title "%s"%s' % (
+                subplot.dat_file, using, axes, style, title, whiskerbars)
             if subplot_no != subplot_count - 1:
                 result += u', \\'
             result += u'\n'

--- a/src/pywws/examples/graph_templates/2016candle.png.xml
+++ b/src/pywws/examples/graph_templates/2016candle.png.xml
@@ -1,0 +1,54 @@
+<?xml version="1.0" encoding="utf-8"?>
+<graph>
+  <!--
+  pywws - Python software for USB Wireless Weather Stations
+  http://github.com/jim-easterbrook/pywws
+  Copyright (C) 2008-13  Jim Easterbrook  jim@jim-easterbrook.me.uk
+
+  This program is free software; you can redistribute it and/or
+  modify it under the terms of the GNU General Public License
+  as published by the Free Software Foundation; either version 2
+  of the License, or (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with this program; if not, write to the Free Software
+  Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+  -->
+  <size>600, 600</size>
+  <fileformat>pngcairo font "arial,11"</fileformat>
+
+  <start>year=2016, month=1, day=1, hour=0</start>
+  <stop>year=2016, month=12, day=31, hour=23</stop>
+  <xformat>%b</xformat>
+  <xlabel>%Y</xlabel>
+  <dateformat/>
+
+  <plot>
+    <title>Temperatur (℃)</title>
+    <yrange>-20, 50</yrange>
+    <grid>ytics</grid>
+    <source>monthly</source>
+    <subplot>
+      <!-- Candlesticks plot with whiskerbars, line width: 2, whiskerbar width: 50% -->
+      <style>candlesticksw 2 0.5</style>
+      <colour>rgb "#f44336"</colour>
+      <xcalc>data['start'] + timedelta(days=15)</xcalc>
+      <!-- 4 values as tuple in that order: NightAvg, NightMin, DayMax, DayAvg -->
+      <ycalc>(data['temp_out_min_ave'], data['temp_out_min_lo'], data['temp_out_max_hi'], data['temp_out_max_ave'])</ycalc>
+    </subplot>
+    <subplot>
+        <!-- This is the median line as per gnuplot documentation -->
+        <style>candlesticks 1.5</style>
+        <colour>rgb "#607d8b"</colour>
+        <xcalc>data['start'] + timedelta(days=15)</xcalc>
+        <!-- 4 times the same value as we don't want a bar but only a line -->
+        <ycalc>(data['temp_out_ave'], data['temp_out_ave'], data['temp_out_ave'], data['temp_out_ave'])</ycalc>
+    </subplot>
+  </plot>
+
+</graph>


### PR DESCRIPTION
You can now specify tuples like ``<ycalc>(1, 2, 3)</ycalc>``. If the
value isn't a tuple, it gets converted to one. The lines for the gnuplot
data file now adapt to the number of elements in the tuple.

Two new styles: ``<style>candlesticks 1.5</style>`` is a candlestick graph
with a line width of 1.5. ``<style>candlesticksw 2 0.5</style>`` is a
candlesticks graph with a line width of 2 and whiskerbars with a width
of 50%.

I also added an example xml. All previous functionality shouldn't be
affected.

Signed-off-by: Markus Birth <mbirth@gmail.com>