### PR TITLE
Return forecast letter without forecast_text

### DIFF
--- a/src/pywws/Forecast.py
+++ b/src/pywws/Forecast.py
@@ -68,6 +68,10 @@ def Zambretti(params, hourly_data):
     code = ZambrettiCode(params, hourly_data)
     return Localisation.translation.ugettext(ZambrettiCore.ZambrettiText(code))
 
+def ZambrettiLetter(params, hourly_data):
+    code = ZambrettiCode(params, hourly_data)
+    return ZambrettiCore.ZambrettiLetter(code)
+  
 def main(argv=None):
     if argv is None:
         argv = sys.argv

--- a/src/pywws/Template.py
+++ b/src/pywws/Template.py
@@ -309,7 +309,7 @@ from pywws.constants import HOUR, SECOND, DAY
 from pywws import conversions
 from pywws.conversions import *
 from pywws import DataStore
-from pywws.Forecast import Zambretti, ZambrettiCode
+from pywws.Forecast import Zambretti, ZambrettiCode, ZambrettiLetter
 from pywws import Localisation
 from pywws.Logger import ApplicationLogger
 from pywws.TimeZone import Local, utc

--- a/src/pywws/ZambrettiCore.py
+++ b/src/pywws/ZambrettiCore.py
@@ -101,6 +101,9 @@ def ZambrettiCode(pressure, month, wind, trend,
 def ZambrettiText(letter):
     return forecast_text[letter]
 
+def ZambrettiLetter(letter):
+    return letter
+
 def main(argv=None):
     from pywws.conversions import winddir_text
     for pressure in range(1030, 960, -10):


### PR DESCRIPTION
This method is useful if you need to display images with forecast on templates.

ex. <img src="A.jpg" /> instead of  "Settled fine"
      <img src="K.jpg" /> instead of  "Fairly fine, showers likely"
