### PR TITLE
Update toservice.py

### DIFF
--- a/src/pywws/toservice.py
+++ b/src/pywws/toservice.py
@@ -331,7 +331,10 @@ class ToService(object):
         mosquitto_client = mosquitto.Mosquitto(client_id)
         if auth:
             self.logger.debug("Username and password configured")
-            mosquitto_client.username_pw_set(self.user, self.password)
+            if(self.password == "unknown"):
+                mosquitto_client.username_pw_set(self.user)
+            else:
+                mosquitto_client.username_pw_set(self.user, self.password)
         else:
             self.logger.debug("Username and password unconfigured, ignoring")
         self.logger.debug(


### PR DESCRIPTION
If the MQTT password is not set, also do not set it in the mqtt client.
Some services only need usernames without passwords to identify a users. If you provide a password authentication fails.