### PR TITLE
Added option for SFTP-authentication with public key

### DIFF
--- a/src/contributors/contributors.txt
+++ b/src/contributors/contributors.txt
@@ -9,9 +9,10 @@ Rod Persky
 Morten Høybye Frederiksen       morten@mfd-consult.dk
 Simon Josefsson                 simon@josefsson.org
 Matthew Hilton                  matthilton2005@gmail.com
-Sabine Tobolka			oe1yvw@gmail.com
+Sabine Tobolka			            oe1yvw@gmail.com
 Markus Birth                    markus@birth-online.de
 Chris Ramsay                    chris@ramsay-family.net
+Christian Benke                 benkokakao@gmail.com
 
 Translators
 -----------

--- a/src/doc/guides/weather_ini.rst
+++ b/src/doc/guides/weather_ini.rst
@@ -283,6 +283,10 @@ Note that you may need to change the ``port`` value when you change to or from s
 
 ``user`` and ``password`` are the FTP site login details. Your web site provider should have provided them to you.
 
+``privkey`` is the path to a private SSH-key_. For SFTP (secure FTP) this can be used for authentication instead of a password, which offers additional benefits in terms of security. When this is used the password-parameter can be left empty.
+
+.. _SSH-key: https://www.ssh.com/ssh/public-key-authentication
+
 ``directory`` specifies where on the FTP site (or local file system) the files should be stored. Note that you may have to experiment with this a bit - you might need a '/' character at the start of the path.
 
 .. versionadded:: 13.12.dev1120


### PR DESCRIPTION
I'm using this for passwordless authentication to my SSH-server, with private and public SSH-keys.

I was not sure how best to handle setting a default password (Used to be set to "secret" if the parameter was missing in weather.ini). I've removed this for now as it seems counterintuitive if you set a privkey-parameter and then automatically get a `password = secret` added in your weather.ini. This can however easily be replaced with the old behaviour without causing any errors (As `_sftp.connect()` first tries the privkey).

I've tested my change with several scenarios - without parameters, with one parameter each, with a broken ssh-key and with a encrypted ssh-key - there are proper and relevant error-messages for error cases and if only one parameter is given it works fine. A proper error-message is also the reason for replacing the paramiko.Transport.connect()-method with the separate methods to initialize the transport, as only these appear to provide relevant exceptions and error-messages.

I've also updated the docs, but I was again not sure if I should add the privkey-parameter in the example-ini - I've left it out, as one can assume a user that uses public key authentication knows what they are doing.