### PR TITLE
Updated to use correct paho client creation, rather than old Mosquitto client.

### DIFF
--- a/src/pywws/toservice.py
+++ b/src/pywws/toservice.py
@@ -331,7 +331,7 @@ class ToService(object):
         del prepared_data['retain']
         del prepared_data['auth']
 
-        mosquitto_client = mosquitto.Mosquitto(client_id, protocol=mosquitto.MQTTv31)
+        mosquitto_client = mosquitto.Client(client_id, protocol=mosquitto.MQTTv31)
         if auth:
             self.logger.debug("Username and password configured")
             if(self.password == "unknown"):


### PR DESCRIPTION
Without this additional change it moans about protocol not being a valid parameter.  
I somehow must have managed to test my old custom version rather than this branch.

Signed-off-by: Ian Wilkinson <null@sgtwilko.f9.co.uk>