### PR TITLE
Publsh to separate Mqtt subtopics

### DIFF
--- a/src/doc/guides/integration.rst
+++ b/src/doc/guides/integration.rst
@@ -128,6 +128,7 @@ See :ref:`Dependencies - MQTT <dependencies-mqtt>` for details.
     user = unknown
     password = unknown
     template = default
+    multi_topic = False
 
     [logged]
     services = ['mqtt', 'underground']
@@ -144,6 +145,10 @@ Otherwise the broker discards the message if no client is subscribing to this to
 This allows clients to get an immediate response when they subscribe to a topic, without having to wait until the next message is published.
 
 ``auth``, ``user`` and ``password`` can be used for MQTT authentication.
+
+``multi_topic`` is a boolean and should be set to ``True`` or ``False``.
+If set to ``True`` pywws will also publish all the data each as separate subtopics of the configured ``topic``;
+i.e., with the ``topic`` set to /weather/pywws pywws will also publish the outside temperature to ``/weather/pywws/temp_out`` and the inside temperature to ``/weather/pywws/temp_in``.  
 
 If these aren't obvious to you it's worth doing a bit of reading around MQTT.
 It's a great lightweight messaging system from IBM, recently made more popular when Facebook published information on their use of it.

--- a/src/pywws/services/mqtt.ini
+++ b/src/pywws/services/mqtt.ini
@@ -30,3 +30,5 @@ port		= *port
 client_id	= *client_id    
 retain      = *retain
 auth        = *auth
+multi_topic = *multi_topic
+

--- a/src/pywws/toservice.py
+++ b/src/pywws/toservice.py
@@ -350,7 +350,6 @@ class ToService(object):
         mosquitto_client.connect(hostname, int(port))
         mosquitto_client.publish(topic, json.dumps(prepared_data), retain=retain)
 
-##        commented out as sending the data as a json object (above)
         if multi_topic:
             for item in prepared_data:
                 if prepared_data[item] == '':

--- a/src/pywws/toservice.py
+++ b/src/pywws/toservice.py
@@ -323,6 +323,7 @@ class ToService(object):
         client_id = prepared_data['client_id']
         retain = prepared_data['retain'] == 'True'
         auth = prepared_data['auth'] == 'True'
+        multi_topic = prepared_data['multi_topic'] == 'True'
         # clean up the object
         del prepared_data['topic']
         del prepared_data['hostname']
@@ -330,6 +331,7 @@ class ToService(object):
         del prepared_data['client_id']
         del prepared_data['retain']
         del prepared_data['auth']
+        del prepared_data['multi_topic']
 
         mosquitto_client = mosquitto.Mosquitto(client_id)
         if auth:
@@ -349,12 +351,12 @@ class ToService(object):
         mosquitto_client.publish(topic, json.dumps(prepared_data), retain=retain)
 
 ##        commented out as sending the data as a json object (above)
-##        for item in prepared_data:
-##            if prepared_data[item] == '':
-##                prepared_data[item] = 'None'
-##            mosquitto_client.publish(
-##                topic + "/" + item + "/" + str(timestamp), prepared_data[item])
-##            time.sleep(0.200)
+        if multi_topic:
+            for item in prepared_data:
+                if prepared_data[item] == '':
+                    prepared_data[item] = 'None'
+                mosquitto_client.publish(topic + "/" + item, prepared_data[item], retain=retain)
+            time.sleep(0.200)
 
         self.logger.debug("published data: %s", prepared_data)
         mosquitto_client.disconnect()

--- a/src/pywws/toservice.py
+++ b/src/pywws/toservice.py
@@ -351,11 +351,13 @@ class ToService(object):
         mosquitto_client.publish(topic, json.dumps(prepared_data), retain=retain)
 
         if multi_topic:
+            #Publish a messages, one for each item in prepared_data to separate Subtopics. 
             for item in prepared_data:
                 if prepared_data[item] == '':
                     prepared_data[item] = 'None'
                 mosquitto_client.publish(topic + "/" + item, prepared_data[item], retain=retain)
-            time.sleep(0.200)
+            #Need to make sure the messages have been flushed to the server.
+            mosquitto_client.loop(timeout=0.5) 
 
         self.logger.debug("published data: %s", prepared_data)
         mosquitto_client.disconnect()


### PR DESCRIPTION
This allow the weather data to be sent to separate MQTT subtopics.

Each item is sent as a subtopic (e.g., pywws will publish the internal temp to `/weather/pywws/temp_in_c` ) allowing for systems that are just interested in one part of the data to subscribe to that topic without having to parse the JSON.

Signed-off-by: Ian Wilkinson <null@sgtwilko.f9.co.uk>