### PR TITLE
Fix bug in converting time zones

### DIFF
--- a/src/pywws/EWtoPy.py
+++ b/src/pywws/EWtoPy.py
@@ -104,7 +104,7 @@ def main(argv=None):
     for line in in_file:
         items = line.split(',')
         local_date = DataStore.safestrptime(items[2].strip(), '%Y-%m-%d %H:%M:%S')
-        local_date = local_date.replace(tzinfo=TimeZone.Local)
+        local_date = TimeZone.Local.localize(local_date)
         date = local_date.astimezone(TimeZone.utc)
         if last_date and date < last_date:
             date = date + timedelta(hours=1)

--- a/src/pywws/Forecast.py
+++ b/src/pywws/Forecast.py
@@ -93,12 +93,12 @@ def main(argv=None):
     hourly_data = DataStore.hourly_store(data_dir)
     idx = hourly_data.before(datetime.max)
     print 'Zambretti (current):', Zambretti(params, hourly_data[idx])
-    idx = idx.replace(tzinfo=utc).astimezone(Local)
+    idx = utc.localize(idx).astimezone(Local)
     if idx.hour < 8 or (idx.hour == 8 and idx.minute < 30):
         idx -= timedelta(hours=24)
     idx = idx.replace(hour=9, minute=0, second=0)
     idx = hourly_data.nearest(idx.astimezone(utc).replace(tzinfo=None))
-    lcl = idx.replace(tzinfo=utc).astimezone(Local)
+    lcl = utc.localize(idx).astimezone(Local)
     print 'Zambretti (at %s):' % lcl.strftime('%H:%M %Z'), Zambretti(
         params, hourly_data[idx])
     return 0

--- a/src/pywws/Plot.py
+++ b/src/pywws/Plot.py
@@ -688,8 +688,8 @@ class BasePlotter(object):
         title = self.graph.get_value('title', '')
         if title:
             if '%' in title:
-                x_hi = (self.x_hi -
-                        self.utcoffset).replace(tzinfo=utc).astimezone(Local)
+                x_hi = utc.localize(
+                    self.x_hi - self.utcoffset).astimezone(Local)
                 if sys.version_info[0] < 3:
                     title = title.encode(self.encoding[0])
                 title = x_hi.strftime(title)
@@ -786,10 +786,8 @@ set timefmt "%Y-%m-%dT%H:%M:%S"
         pressure_offset = self.pressure_offset
         # label x axis of last plot
         if plot_no == self.plot_count - 1:
-            x_lo = (self.x_lo -
-                    self.utcoffset).replace(tzinfo=utc).astimezone(Local)
-            x_hi = (self.x_hi -
-                    self.utcoffset).replace(tzinfo=utc).astimezone(Local)
+            x_lo = utc.localize(self.x_lo - self.utcoffset).astimezone(Local)
+            x_hi = utc.localize(self.x_hi - self.utcoffset).astimezone(Local)
             if self.duration <= timedelta(hours=24):
                 # TX_NOTE Keep the "(%Z)" formatting string
                 xlabel = _('Time (%Z)')

--- a/src/pywws/Template.py
+++ b/src/pywws/Template.py
@@ -424,8 +424,7 @@ class Template(object):
                     if isinstance(x, datetime):
                         if round_time:
                             x += round_time
-                        x = x.replace(tzinfo=utc)
-                        x = x.astimezone(time_zone)
+                        x = utc.localize(x).astimezone(time_zone)
                     # convert data
                     if x is not None and len(command) > 3:
                         x = eval(command[3])
@@ -503,10 +502,10 @@ class Template(object):
                     prevdata = data
                     time_str = command[1]
                     if '%' in time_str:
-                        lcl = idx.replace(tzinfo=utc).astimezone(time_zone)
+                        lcl = utc.localize(idx).astimezone(time_zone)
                         time_str = lcl.strftime(time_str)
                     new_idx = DataStore.safestrptime(time_str)
-                    new_idx = new_idx.replace(tzinfo=time_zone).astimezone(utc)
+                    new_idx = time_zone.localize(new_idx).astimezone(utc)
                     new_idx = data_set.after(new_idx.replace(tzinfo=None))
                     if new_idx:
                         idx = new_idx
@@ -553,7 +552,7 @@ class Template(object):
 
     def _rain_day(self, data):
         if not self.midnight:
-            self.midnight = datetime.utcnow().replace(tzinfo=utc).astimezone(
+            self.midnight = utc.localize(datetime.utcnow()).astimezone(
                 Local).replace(hour=0, minute=0, second=0).astimezone(
                     utc).replace(tzinfo=None)
         while data['idx'] < self.midnight:

--- a/src/pywws/YoWindow.py
+++ b/src/pywws/YoWindow.py
@@ -58,7 +58,7 @@ class YoWindow(object):
         self.logger = logging.getLogger('pywws.YoWindow')
         self.data = calib_data
         # compute local midnight
-        self.midnight = datetime.utcnow().replace(tzinfo=utc).astimezone(
+        self.midnight = utc.localize(datetime.utcnow()).astimezone(
             Local).replace(hour=0, minute=0, second=0).astimezone(
                 utc).replace(tzinfo=None)
         self.day = timedelta(hours=24)

--- a/src/pywws/__init__.py
+++ b/src/pywws/__init__.py
@@ -1,3 +1,3 @@
-__version__ = '18.04.0'
-_release = '1387'
-_commit = 'c51fd36'
+__version__ = '18.04.1'
+_release = '1388'
+_commit = 'bba29e3'


### PR DESCRIPTION
The pytz library does not always work correctly when doing
dt.replace(tzinfo=tz_object). The correct thing to do is
tz_object.localize(dt).