### PR TITLE
Improved resilience by removing some occurrences of eval(…)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,4 @@ src/doc/api/pywws.*.rst
 
 # Compiled language files
 *.mo
+*.stackdump

--- a/src/contributors/contributors.txt
+++ b/src/contributors/contributors.txt
@@ -16,6 +16,7 @@ Christian Benke                 benkokakao@gmail.com
 Ian Wilkinson                   null@sgtwilko.f9.co.uk
 Tim Richardson                  tim@potton.me.uk
 Richard Truran                  ashenshugar@outlook.com
+Mark Jarvis                     jarvism@thisaddressdoesnotexist.co.uk
 
 Translators
 -----------

--- a/src/pywws/calib.py
+++ b/src/pywws/calib.py
@@ -43,7 +43,7 @@ you can create a plain text file in your ``modules`` directory, e.g.
 
     class Calib(object):
         def __init__(self, params, stored_data):
-            self.pressure_offset = eval(params.get('config', 'pressure offset'))
+            self.pressure_offset = float(params.get('config', 'pressure offset'))
 
         def calib(self, raw):
             result = dict(raw)
@@ -101,7 +101,7 @@ class DefaultCalib(object):
 
     """
     def __init__(self, params, stored_data):
-        self.pressure_offset = eval(params.get('config', 'pressure offset'))
+        self.pressure_offset = float(params.get('config', 'pressure offset'))
 
     def calib(self, raw):
         result = dict(raw)

--- a/src/pywws/examples/modules/aws_api_gw_service.py
+++ b/src/pywws/examples/modules/aws_api_gw_service.py
@@ -37,7 +37,7 @@ supports optional extra headers.
 """
 
 from __future__ import absolute_import, unicode_literals
-
+from ast import literal_eval
 from contextlib import contextmanager
 from datetime import timedelta
 import logging
@@ -103,7 +103,7 @@ class ToService(pywws.service.CatchupDataService):
     def upload_data(self, session, prepared_data={}):
         try:
             if self.params['http headers']:
-                for header in eval(self.params['http headers']):
+                for header in literal_eval(self.params['http headers']):
                     session.headers.update({header[0]: header[1]})
             rsp = session.get(self.params['api url'], params=prepared_data,
                 timeout=60)

--- a/src/pywws/examples/modules/default.py
+++ b/src/pywws/examples/modules/default.py
@@ -19,7 +19,7 @@
 class Calib(object):
     """Minimum weather station calibration class."""
     def __init__(self, params, raw_data):
-        self.pressure_offset = eval(params.get('config', 'pressure offset'))
+        self.pressure_offset = float(params.get('config', 'pressure offset'))
 
     def calib(self, raw):
         result = dict(raw)

--- a/src/pywws/examples/modules/filter_wind_dir.py
+++ b/src/pywws/examples/modules/filter_wind_dir.py
@@ -23,7 +23,7 @@ import pywws.process
 class Calib(object):
     """Weather station calibration class with wind direction filter."""
     def __init__(self, params, raw_data):
-        self.pressure_offset = eval(params.get('config', 'pressure offset'))
+        self.pressure_offset = float(params.get('config', 'pressure offset'))
         self.raw_data = raw_data
         self.wind_fil_aperture = timedelta(minutes=29)
 

--- a/src/pywws/examples/modules/remove_temperature_spikes.py
+++ b/src/pywws/examples/modules/remove_temperature_spikes.py
@@ -29,7 +29,7 @@ class Calib(object):
     """Weather station calibration class with temperature spike removal."""
     def __init__(self, params, raw_data):
         self.raw_data = raw_data
-        self.pressure_offset = eval(params.get('config', 'pressure offset'))
+        self.pressure_offset = float(params.get('config', 'pressure offset'))
 
     def calib(self, raw):
         result = dict(raw)

--- a/src/pywws/forecast.py
+++ b/src/pywws/forecast.py
@@ -83,9 +83,9 @@ def zambretti_code(params, hourly_data):
     Inspired by beteljuice.com Java algorithm, as converted to Python by
     honeysucklecottage.me.uk, and further information
     from http://www.meteormetrics.com/zambretti.htm"""
-    north = eval(params.get('Zambretti', 'north', 'True'))
-    baro_upper = eval(params.get('Zambretti', 'baro upper', '1050.0'))
-    baro_lower = eval(params.get('Zambretti', 'baro lower', '950.0'))
+    north = bool(params.get('Zambretti', 'north', 'True'))
+    baro_upper = float(params.get('Zambretti', 'baro upper', '1050.0'))
+    baro_lower = float(params.get('Zambretti', 'baro lower', '950.0'))
     if not hourly_data['rel_pressure']:
         return ''
     if hourly_data['wind_ave'] is None or hourly_data['wind_ave'] < 0.3:

--- a/src/pywws/forecast.py
+++ b/src/pywws/forecast.py
@@ -38,7 +38,7 @@ __usage__ = __doc__.split('\n')[0] + __usage__
 from datetime import datetime, timedelta
 import getopt
 import sys
-
+from ast import literal_eval
 import pywws.localisation
 import pywws.storage
 from pywws.timezone import timezone
@@ -83,7 +83,7 @@ def zambretti_code(params, hourly_data):
     Inspired by beteljuice.com Java algorithm, as converted to Python by
     honeysucklecottage.me.uk, and further information
     from http://www.meteormetrics.com/zambretti.htm"""
-    north = bool(params.get('Zambretti', 'north', 'True'))
+    north = literal_eval(params.get('Zambretti', 'north', 'True'))
     baro_upper = float(params.get('Zambretti', 'baro upper', '1050.0'))
     baro_lower = float(params.get('Zambretti', 'baro lower', '950.0'))
     if not hourly_data['rel_pressure']:

--- a/src/pywws/plot.py
+++ b/src/pywws/plot.py
@@ -589,10 +589,8 @@ class BasePlotter(object):
         self.daily_data = context.daily_data
         self.monthly_data = context.monthly_data
         self.work_dir = work_dir
-        self.pressure_offset = eval(
-            context.params.get('config', 'pressure offset'))
-        self.gnuplot_version = eval(
-            context.params.get('config', 'gnuplot version', '4.2'))
+        self.pressure_offset = float(context.params.get('config', 'pressure offset'))
+        self.gnuplot_version = float(context.params.get('config', 'gnuplot version', '4.2'))
         self.computations = Computations(context)
         # set language related stuff
         self.encoding = context.params.get(

--- a/src/pywws/process.py
+++ b/src/pywws/process.py
@@ -74,6 +74,7 @@ __usage__ = __doc__.split('\n')[0] + __usage__
 
 from collections import deque
 from datetime import date, datetime, timedelta
+from ast import literal_eval
 import getopt
 import logging
 import math
@@ -717,7 +718,7 @@ def generate_monthly(rain_day_threshold, day_end_hour, use_dst,
 
 def get_day_end_hour(params):
     # get daytime end hour (in local time)
-    day_end_hour, use_dst = eval(
+    day_end_hour, use_dst = literal_eval(
         params.get('config', 'day end hour', '9, False'))
     day_end_hour = day_end_hour % 24
     return day_end_hour, use_dst
@@ -740,7 +741,7 @@ def process_data(context):
     # get daytime end hour (in local time)
     day_end_hour, use_dst = get_day_end_hour(context.params)
     # get other config
-    rain_day_threshold = eval(context.params.get('config', 'rain day threshold', '0.2'))
+    rain_day_threshold = float(context.params.get('config', 'rain day threshold', '0.2'))
     # calibrate raw data
     start = calibrate_data(context.params, context.raw_data, context.calib_data)
     # generate hourly data

--- a/src/pywws/regulartasks.py
+++ b/src/pywws/regulartasks.py
@@ -26,7 +26,7 @@ import logging
 import os
 import sys
 import time
-
+from ast import literal_eval
 from pywws.calib import Calib
 import pywws.plot
 import pywws.template
@@ -46,7 +46,7 @@ class RegularTasks(object):
         self.hourly_data = context.hourly_data
         self.daily_data = context.daily_data
         self.monthly_data = context.monthly_data
-        self.flush = eval(self.params.get('config', 'frequent writes', 'False'))
+        self.flush = bool(self.params.get('config', 'frequent writes', 'False'))
         # get directories
         self.template_dir = self.params.get(
             'paths', 'templates', os.path.expanduser('~/weather/templates/'))
@@ -104,16 +104,16 @@ class RegularTasks(object):
     def has_live_tasks(self):
         if self.cron:
             return True
-        for name in eval(self.params.get('live', 'services', '[]')):
+        for name in literal_eval(self.params.get('live', 'services', '[]')):
             return True
-        for template in eval(self.params.get('live', 'plot', '[]')):
+        for template in literal_eval(self.params.get('live', 'plot', '[]')):
             return True
-        for template in eval(self.params.get('live', 'text', '[]')):
+        for template in literal_eval(self.params.get('live', 'text', '[]')):
             return True
         return False
 
     def _parse_templates(self, section, option):
-        for template in eval(self.params.get(section, option, '[]')):
+        for template in literal_eval(self.params.get(section, option, '[]')):
             if isinstance(template, (list, tuple)):
                 yield template[0], template[1:]
             else:

--- a/src/pywws/regulartasks.py
+++ b/src/pywws/regulartasks.py
@@ -46,7 +46,7 @@ class RegularTasks(object):
         self.hourly_data = context.hourly_data
         self.daily_data = context.daily_data
         self.monthly_data = context.monthly_data
-        self.flush = bool(self.params.get('config', 'frequent writes', 'False'))
+        self.flush = literal_eval(self.params.get('config', 'frequent writes', 'False'))
         # get directories
         self.template_dir = self.params.get(
             'paths', 'templates', os.path.expanduser('~/weather/templates/'))

--- a/src/pywws/service/__init__.py
+++ b/src/pywws/service/__init__.py
@@ -24,7 +24,7 @@
 """
 
 from __future__ import absolute_import, print_function, unicode_literals
-
+from ast import literal_eval
 from collections import deque
 from datetime import datetime, timedelta
 import os
@@ -223,7 +223,7 @@ class DataServiceBase(ServiceBase):
     """Defines the conversion of pywws data to key, value pairs required
     by the service. The template string is passed to
     :py:mod:`pywws.template`, then the result is passed to
-    :py:func:`eval` to create a :py:obj:`dict`. This rather complex
+    :py:func:`literal_eval` to create a :py:obj:`dict`. This rather complex
     process allows great flexibility, but you do have to be careful with
     use of quotation marks.
     """
@@ -287,7 +287,7 @@ class DataServiceBase(ServiceBase):
             self.template_file = StringIO(self.template)
         data_str = self.templater.make_text(self.template_file, data)
         self.template_file.seek(0)
-        return eval('{' + data_str + '}')
+        return literal_eval('{' + data_str + '}')
 
     def valid_data(self, data):
         return True
@@ -417,7 +417,7 @@ class FileService(ServiceBase):
 
     """
     def do_catchup(self, do_all=False):
-        self.upload(options=eval(
+        self.upload(options=literal_eval(
             self.context.status.get('pending', self.service_name, '[]')))
         return True
 
@@ -428,7 +428,7 @@ class FileService(ServiceBase):
             self.queue.append(item)
 
     def upload_batch(self):
-        pending = eval(
+        pending = literal_eval(
             self.context.status.get('pending', self.service_name, '[]'))
         OK = True
         count = 0

--- a/src/pywws/service/ftp.py
+++ b/src/pywws/service/ftp.py
@@ -82,7 +82,7 @@ class ToService(pywws.service.FileService):
 
     def __init__(self, context, check_params=True):
         super(ToService, self).__init__(context, check_params)
-        self.params['port'] = eval(self.params['port'])
+        self.params['port'] = int(self.params['port'])
 
     @contextmanager
     def session(self):

--- a/src/pywws/service/mqtt.py
+++ b/src/pywws/service/mqtt.py
@@ -112,7 +112,7 @@ for adding the retain and auth options.
 """
 
 from __future__ import absolute_import, unicode_literals
-
+from ast import literal_eval
 from contextlib import contextmanager
 from datetime import timedelta
 import json
@@ -167,13 +167,13 @@ class ToService(pywws.service.LiveDataService):
     def __init__(self, context, check_params=True):
         super(ToService, self).__init__(context, check_params)
         # get template text
-        template = eval(context.params.get(
+        template = literal_eval(context.params.get(
             service_name, 'template_txt', pprint.pformat(self.template)))
         logger.log(logging.DEBUG - 1, 'template:\n' + template)
         self.template = "#live#" + template
         # convert some params from string
         for key in ('port', 'retain', 'tls_ver', 'multi_topic'):
-            self.params[key] = eval(self.params[key])
+            self.params[key] = literal_eval(self.params[key])
 
     @contextmanager
     def session(self):

--- a/src/pywws/service/sftp.py
+++ b/src/pywws/service/sftp.py
@@ -101,7 +101,7 @@ class ToService(pywws.service.FileService):
 
     def __init__(self, context, check_params=True):
         super(ToService, self).__init__(context, check_params)
-        self.params['port'] = eval(self.params['port'])
+        self.params['port'] = int(self.params['port'])
         if self.params['privkey']:
             self.params['privkey'] = paramiko.RSAKey.from_private_key_file(
                 self.params['privkey'])

--- a/src/pywws/service/underground.py
+++ b/src/pywws/service/underground.py
@@ -50,7 +50,7 @@ normal server for past data.
 """
 
 from __future__ import absolute_import, unicode_literals
-
+from ast import literal_eval
 from contextlib import contextmanager
 from datetime import datetime, timedelta
 import logging
@@ -99,7 +99,7 @@ class ToService(pywws.service.CatchupDataService):
 #illuminance  "'solarradiation': '%.2f'," "" "illuminance_wm2(x)"#
 #uv           "'UV'            : '%d',"#
 """
-        if eval(self.params['internal']):
+        if literal_eval(self.params['internal']):
             self.template += """
 #hum_in       "'indoorhumidity': '%.d',"#
 #temp_in      "'indoortempf'   : '%.1f'," "" "temp_f(x)"#

--- a/src/pywws/service/weathercloud.py
+++ b/src/pywws/service/weathercloud.py
@@ -35,7 +35,7 @@
 """
 
 from __future__ import absolute_import, unicode_literals
-
+from ast import literal_eval
 from contextlib import contextmanager
 from datetime import timedelta
 import logging
@@ -111,7 +111,7 @@ class ToService(pywws.service.LiveDataService):
 #uv
     "'uvi'     : '%.0f'," "" "scale(x, 10.0)"#
 """
-        if eval(self.params['internal']):
+        if literal_eval(self.params['internal']):
             self.template += """
 #temp_in
     "'tempin'  : '%.0f'," "" "scale(x, 10.0)"#

--- a/src/pywws/storage.py
+++ b/src/pywws/storage.py
@@ -68,7 +68,7 @@ Detailed API
 """
 
 from __future__ import with_statement
-
+from ast import literal_eval
 from contextlib import contextmanager
 import csv
 from datetime import date, datetime, timedelta, MAXYEAR
@@ -819,8 +819,8 @@ class PywwsContext(object):
                         'live', 'logged', 'hourly', '12 hourly', 'daily']:
                     continue
                 for t_p in ('text', 'plot'):
-                    templates = eval(self.params.get(section, t_p, '[]'))
-                    services = eval(self.params.get(section, 'services', '[]'))
+                    templates = literal_eval(self.params.get(section, t_p, '[]'))
+                    services = literal_eval(self.params.get(section, 'services', '[]'))
                     changed = False
                     for n, template in enumerate(templates):
                         if isinstance(template, (list, tuple)):

--- a/src/pywws/template.py
+++ b/src/pywws/template.py
@@ -301,6 +301,7 @@ __usage__ = __doc__.split('\n')[0] + __usage__
 
 import codecs
 from datetime import datetime, timedelta
+from ast import literal_eval
 import getopt
 import locale
 import logging
@@ -396,8 +397,8 @@ class Template(object):
         rain_hour = self.computations.rain_hour
         rain_day = self.computations.rain_day
         rain_24hr = self.computations.rain_24hr
-        pressure_offset = eval(self.params.get('config', 'pressure offset'))
-        fixed_block = eval(self.status.get('fixed', 'fixed block'))
+        pressure_offset = float(self.params.get('config', 'pressure offset'))
+        fixed_block = literal_eval(self.status.get('fixed', 'fixed block'))
         # start off with no time rounding
         round_time = None
         # start off in hourly data mode

--- a/src/pywws/weatherstation.py
+++ b/src/pywws/weatherstation.py
@@ -79,6 +79,7 @@ from __future__ import absolute_import
 __docformat__ = "restructuredtext en"
 
 from datetime import datetime
+from ast import literal_eval
 import logging
 import sys
 import time
@@ -393,9 +394,9 @@ class DriftingClock(object):
         self.period = period
         self.margin = margin
         if self.status:
-            self.clock = eval(
+            self.clock = literal_eval(
                 self.status.get('clock', self.name, 'None'))
-            self.drift = eval(
+            self.drift = literal_eval(
                 self.status.get('clock', self.name + ' drift', '0.0'))
         else:
             self.clock = None
@@ -469,8 +470,7 @@ class WeatherStation(object):
         # init variables
         if context:
             self.status = context.status
-            self.avoid = eval(
-                context.params.get('config', 'usb activity margin', '3.0'))
+            self.avoid = float(context.params.get('config', 'usb activity margin', '3.0'))
             self.avoid = max(self.avoid, 0.0)
             self.ws_type = context.params.get('config', 'ws type', 'Unknown')
         else:


### PR DESCRIPTION
Removed numerous `eval()` functions with safer `int()`, `float()`, `bool()` or `literal_eval()` from "`ast`" library. This was to reduce risk of executable python statements in the config files causing issues.

Signed-off-by: Mark Jarvis <jarvism@thisaddressdoesnotexist.co.uk>