### PR TITLE
Update weathercloud service to upload both average and current wind data

### DIFF
--- a/src/pywws/service/weathercloud.py
+++ b/src/pywws/service/weathercloud.py
@@ -128,7 +128,7 @@ class ToService(pywws.service.LiveDataService):
 
     def valid_data(self, data):
         return any([data[x] is not None for x in (
-            'wind_dir', 'wind_dir_ave', 'wind_speed', 'wind_speed_ave', 'wind_gust', 'hum_out', 'temp_out',
+            'wind_dir', 'wind_ave', 'wind_gust', 'hum_out', 'temp_out',
             'temp_in', 'hum_in', 'rel_pressure')])
 
     def upload_data(self, session, prepared_data={}):

--- a/src/pywws/service/weathercloud.py
+++ b/src/pywws/service/weathercloud.py
@@ -79,13 +79,13 @@ class ToService(pywws.service.LiveDataService):
     "'heat'     : '%.0f'," "" "scale(x, 10.0)"#
 #hum_out
     "'hum'      : '%.d',"#
-#wind_speed_ave
+#wind_ave
     "'wspdavg'  : '%.0f'," "" "scale(x, 10.0)"#
-#wind_speed
+#wind_ave
     "'wspd'     : '%.0f'," "" "scale(x, 10.0)"#
 #wind_gust
     "'wspdhi'   : '%.0f'," "" "scale(x, 10.0)"#
-#wind_dir_avg
+#wind_dir
     "'wdiravg'  : '%.0f'," "" "winddir_degrees(x)"#
 #wind_dir
     "'wdir'     : '%.0f'," "" "winddir_degrees(x)"#

--- a/src/pywws/service/weathercloud.py
+++ b/src/pywws/service/weathercloud.py
@@ -79,10 +79,14 @@ class ToService(pywws.service.LiveDataService):
     "'heat'     : '%.0f'," "" "scale(x, 10.0)"#
 #hum_out
     "'hum'      : '%.d',"#
-#wind_ave
+#wind_speed_ave
+    "'wspdavg'  : '%.0f'," "" "scale(x, 10.0)"#
+#wind_speed
     "'wspd'     : '%.0f'," "" "scale(x, 10.0)"#
 #wind_gust
     "'wspdhi'   : '%.0f'," "" "scale(x, 10.0)"#
+#wind_dir_avg
+    "'wdiravg'  : '%.0f'," "" "winddir_degrees(x)"#
 #wind_dir
     "'wdir'     : '%.0f'," "" "winddir_degrees(x)"#
 #rel_pressure
@@ -124,7 +128,7 @@ class ToService(pywws.service.LiveDataService):
 
     def valid_data(self, data):
         return any([data[x] is not None for x in (
-            'wind_dir', 'wind_ave', 'wind_gust', 'hum_out', 'temp_out',
+            'wind_dir', 'wind_dir_ave', 'wind_speed', 'wind_speed_ave', 'wind_gust', 'hum_out', 'temp_out',
             'temp_in', 'hum_in', 'rel_pressure')])
 
     def upload_data(self, session, prepared_data={}):


### PR DESCRIPTION
The recent change to the weathercloud service uploader breaks the trend charting for wind speed as only average wind speed and direction are used.
The advice from weathercloud team is to upload the wspd and wdir values also as wspdavg and wdiravg

Hi Craig,
Thank you for using Weathercloud.
The wspdavg and wdiravg are the 10-min average wind speed and direction values.
Jim can calculate these 2 parameters or send the wspd and wdir values also as wspdavg and wdiravg.
He will find all the information in the API Documentation that we sent him.
Regards,
--
The Weathercloud team

Thanks Richard