### PR TITLE
Do additional check on humidity value

### DIFF
--- a/src/pywws/conversions.py
+++ b/src/pywws/conversions.py
@@ -194,6 +194,8 @@ def dew_point(temp, hum):
     """
     if temp is None or hum is None:
         return None
+    if hum <= 0:
+        return None
     a = 17.27
     b = 237.7
     gamma = ((a * temp) / (b + temp)) + math.log(float(hum) / 100.0)


### PR DESCRIPTION
Sometimes odd old values from files break pywws. I could not figure out where this is stored.

  File "/usr/local/lib/python3.9/dist-packages/pywws/conversions.py", line 199, in dew_point
    gamma = ((a * temp) / (b + temp)) + math.log(float(hum) / 100.0)
ValueError: math domain error

An addtional check fixes this.