### PR TITLE
make distutils optional because it has been removed

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,10 @@
 from __future__ import with_statement
 
 from datetime import date
-from distutils.command.upload import upload
+try:
+    from distutils.command.upload import upload
+except ImportError:
+    class upload: pass
 import os
 from setuptools import setup
 import sys


### PR DESCRIPTION
Distutils has been removed from Python:
https://peps.python.org/pep-0632/

Update setup.py so it's optional, I'd recommend to switch to pyproject.toml instead of setup.py.