### PR TITLE
Move git tag generation to a separate file

### DIFF
--- a/developer/README.rst
+++ b/developer/README.rst
@@ -1,0 +1,7 @@
+Notes for developers
+====================
+
+Releases
+--------
+
+After uploading a new release to PyPI a GitHub tag and corresponding message can be created by running ``python3 developer/tag_release.py``.

--- a/developer/tag_release.py
+++ b/developer/tag_release.py
@@ -1,0 +1,58 @@
+# python-gphoto2 - Python interface to libgphoto2
+# http://github.com/jim-easterbrook/python-gphoto2
+# Copyright (C) 2024  pywws contributors
+#
+# This file is part of pywws.
+#
+# pywws is free software: you can redistribute it and/or modify it under
+# the terms of the GNU Lesser General Public License as published by the
+# Free Software Foundation, either version 3 of the License, or (at your
+# option) any later version.
+#
+# pywws is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public
+# License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with pywws.  If not, see
+# <https://www.gnu.org/licenses/>.
+
+import os
+import sys
+
+# requires GitPython - 'pip install --user gitpython'
+import git
+
+
+# get root dir
+root = os.path.dirname(os.path.dirname(os.path.abspath(sys.argv[0])))
+# read current version info without importing pywws package
+init_file = os.path.join(root, 'src', 'pywws', '__init__.py')
+if sys.version_info[0] >= 3:
+    with open('src/pywws/__init__.py') as f:
+        exec(f.read())
+else:
+    execfile('src/pywws/__init__.py')
+
+
+def main(argv=None):
+    # create git message
+    message = __version__ + '\n\n'
+    with open(os.path.join(root, 'CHANGELOG.txt')) as cl:
+        while not cl.readline().startswith('Changes'):
+            pass
+        while True:
+            line = cl.readline().strip()
+            if not line:
+                break
+            message += line + '\n'
+    repo = git.Repo()
+    tag = repo.create_tag(__version__, message=message)
+    remote = repo.remotes.origin
+    remote.push(tags=True)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 # pywws - Python software for USB Wireless Weather Stations
 # http://github.com/jim-easterbrook/pywws
-# Copyright (C) 2008-23  pywws contributors
+# Copyright (C) 2008-24  pywws contributors
 
 # This program is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License
@@ -19,7 +19,6 @@
 from __future__ import with_statement
 
 from datetime import date
-from distutils.command.upload import upload
 import os
 from setuptools import setup
 import sys
@@ -32,7 +31,7 @@ else:
     execfile('src/pywws/__init__.py')
 
 # get GitHub repo information
-# requires GitPython - 'sudo pip install gitpython'
+# requires GitPython - 'pip install --user gitpython'
 try:
     import git
 except ImportError:
@@ -136,28 +135,6 @@ except ImportError:
 command_options['upload_docs'] = {
     'upload_dir' : ('setup.py', 'doc'),
     }
-
-# modify upload class to add appropriate tag
-# requires GitPython - 'sudo pip install gitpython'
-class upload_and_tag(upload):
-    def run(self):
-        result = upload.run(self)
-        import git
-        message = __version__ + '\n\n'
-        with open('CHANGELOG.txt') as cl:
-            while not cl.readline().startswith('Changes'):
-                pass
-            while True:
-                line = cl.readline().strip()
-                if not line:
-                    break
-                message += line + '\n'
-        repo = git.Repo()
-        tag = repo.create_tag(__version__, message=message)
-        remote = repo.remotes.origin
-        remote.push(tags=True)
-        return result
-cmdclass['upload'] = upload_and_tag
 
 # set options for building distributions
 command_options['sdist'] = {


### PR DESCRIPTION
This simplifies setup.py by removing stuff that's only used by the pywws maintainer, and makes pull request #118 redundant.