### PR TITLE
Added Bluesky as a service

### DIFF
--- a/src/contributors/contributors.txt
+++ b/src/contributors/contributors.txt
@@ -19,6 +19,7 @@ Richard Truran                  ashenshugar@outlook.com
 Mark Jarvis                     jarvism@thisaddressdoesnotexist.co.uk
 Vladimir Michl                  vladimir.michl.vt@gmail.com
 David Bowen                     david@myforest.com
+Henry Collet                    henry@henryandsophie.com
 
 Translators
 -----------

--- a/src/pywws/examples/graph_templates/skeet.png.xml
+++ b/src/pywws/examples/graph_templates/skeet.png.xml
@@ -1,0 +1,48 @@
+<?xml version="1.0"?>
+<graph>
+  <terminal>png small size 440,220</terminal>
+  <lmargin>6</lmargin>
+  <rmargin>7</rmargin>
+  <duration>hours=24</duration>
+  <xtics>2</xtics>
+  <xformat>%H%M</xformat>
+  <xlabel></xlabel>
+  <dateformat></dateformat>
+  <plot>
+    <bmargin>1</bmargin>
+    <yrange>-10, 35</yrange>
+    <source>raw</source>
+    <subplot>
+      <colour>1</colour>
+      <title>Temperature (°C)</title>
+      <ycalc>data['temp_out']</ycalc>
+    </subplot>
+    <subplot>
+      <colour>3</colour>
+      <ycalc>dew_point(data['temp_out'], data['hum_out'])</ycalc>
+      <title>Dew point (°C)</title>
+    </subplot>
+  </plot>
+  <plot>
+    <bmargin>1.6</bmargin>
+    <title>Rainfall (mm)</title>
+    <yrange>0, 6</yrange>
+    <y2range>0, 30</y2range>
+    <ylabel>hourly</ylabel>
+    <y2label>total</y2label>
+    <source>hourly</source>
+    <subplot>
+      <colour>5</colour>
+      <style>box</style>
+      <xcalc>data['idx'].replace(minute=30, second=0)</xcalc>
+      <ycalc>data['rain']</ycalc>
+      <title>hourly</title>
+    </subplot>
+    <subplot>
+      <colour>3</colour>
+      <axes>x1y2</axes>
+      <ycalc>data['rain'] + last_ycalc</ycalc>
+      <title>total</title>
+    </subplot>
+  </plot>
+</graph>

--- a/src/pywws/examples/templates/skeet.txt
+++ b/src/pywws/examples/templates/skeet.txt
@@ -1,0 +1,12 @@
+#hourly#
+#timezone local#
+#roundtime True#
+#idx "%H:%M %Z: "#
+#temp_out "%.1f°C, " "-, "#
+#hum_out "%d%%, " "-, "#
+#wind_ave "%.1f / " "- / " "wind_mph(x)"#
+#wind_gust "%.1f mph " "- mph " "wind_mph(x)"#
+#wind_dir "%s, " "-, " "winddir_text(x)"#
+#rain "%.1f mm/hr, "#
+#rel_pressure "%.0f hPa "#
+#pressure_trend "%s" "" "pressure_trend_text(x)"#

--- a/src/pywws/examples/templates/skeet_media.txt
+++ b/src/pywws/examples/templates/skeet_media.txt
@@ -1,0 +1,13 @@
+media skeet.png
+#hourly#
+#timezone local#
+#roundtime True#
+#idx "%H:%M %Z: "#
+#temp_out "%.1f°C, " "-, "#
+#hum_out "%d%%, " "-, "#
+#wind_ave "%.1f / " "- / " "wind_mph(x)"#
+#wind_gust "%.1f mph " "- mph " "wind_mph(x)"#
+#wind_dir "%s, " "-, " "winddir_text(x)"#
+#rain "%.1f mm/hr, "#
+#rel_pressure "%.0f hPa "#
+#pressure_trend "%s" "" "pressure_trend_text(x)"#

--- a/src/pywws/service/bluesky.py
+++ b/src/pywws/service/bluesky.py
@@ -1,0 +1,200 @@
+# pywws - Python software for USB Wireless Weather Stations
+# http://github.com/jim-easterbrook/pywws
+# Copyright (C) 2008-24  pywws contributors
+
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+
+"""Post messages to Bluesky.
+
+Bluesky is a micro-blogging system that is a whole lot better than the
+cesspool Twitter has become under Space Karen. This module
+sends "skeets", with optional image files, typically to report on weather
+conditions every hour.
+
+
+* Create account: https://bsky.app/
+* Example ``weather.ini`` configuration::
+
+    [bluesky]
+    handle = bishopstonwthr.bsky.social
+    password = xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+
+    [hourly]
+    text = ['skeet.txt', '24hrs.txt']
+    plot = ['24hrs.png.xml', 'rose_12hrs.png.xml']
+    services = [('bluesky', 'skeet.txt'), ('ftp', '24hrs.png', 'rose_12hrs.png')]
+
+Create an account
+-----------------
+
+You could post weather updates to your regular Bluesky but it may be 
+cleaner to have a separate account just for weather reports.
+
+The :py:mod:`pywws.service.bluesky` module requires you to install an
+additional dependency::
+
+    sudo pip install atprototools
+
+Authorise pywws
+---------------
+
+Before you can send "skeets" you need to authorise pywws to post to your
+account. If you run pywws on a low power device such as a Raspberry Pi,
+you may find it easier to generate an app password on a browser on
+another computer and type the values into the ``weather.ini`` file using
+any text editor.
+
+Log into your Bluesky account in a browser and navigate to Settings ->
+Privacy and security -> App Passwords -> Add App Password. Give it a 
+memorable name (or use a randomly generated one) and then make a note of
+the password in the next section; it won't be displayed again. This 
+password will give access to your account, and should be kept
+confidential.
+
+Create a template
+-----------------
+
+A "skeet" is a short text of up to 300 characters. It's up to you what to
+put in your "skeet" but an example is included to get your started. Copy
+the example template ``skeet.txt`` to your template directory, then edit
+it to suit your preferences. (Note hashtags are not automatically
+rendered as hash tags, and getting them to work is complicated as you
+have to figure out the start/end position in the post text, that's just
+too hard for this currently). You should also check it uses the same text
+encoding as your other templates. The example template includes a
+``media`` line to send a graph. Either remove this or copy the example
+graph template ``tweet.png.xml`` to your graph templates directory, if
+you don't already have one there.
+
+Now generate a skeet file from your template, for example::
+
+    python -m pywws.template ~/weather/data ~/weather/templates/skeet.txt skeet.txt
+    cat skeet.txt
+
+Post your first skeet
+--------------------
+
+Now you are ready to run :py:mod:`pywws.service.bluesky`::
+
+    python -m pywws.service.bluesky ~/weather/data skeet.txt
+
+If this works, your new Bluesky account will have posted its first
+weather report. (You can delete the skeet.txt file now.)
+
+Add Bluesky posts to your hourly tasks
+---------------------------------------
+
+Edit the ``[hourly]`` section in ``weather.ini``. If your skeets include
+one or more graphs you need to add the graph templates to the ``plot``
+list. Note that if you reuse your Twitter graph you only need to
+generate it once. Add your skeet template to the ``text`` list. Finally,
+add ``bluesky`` to the ``services`` list, with an option specifying the
+template processing result. For example::
+
+    [hourly]
+    text = ['skeet.txt']
+    plot = ['tweet.png.xml']
+    services = [('bluesky', 'skeet.txt')]
+
+You could use the ``[logged]``, ``[12 hourly]`` or ``[daily]`` sections
+instead, but I think ``[hourly]`` is most appropriate for Bluesky
+updates.
+
+Include images in your skeet
+----------------------------
+
+Each post contains up to four images, and each image can have its own
+alt text and is limited to 1,000,000 bytes in size. However, the
+atprototools libary used to interface with Bluesky is currently coded
+to just manage a single image; it also cannot accept ALT text for the
+image.
+
+To include an image ensure the first line of the skeet is ``media path``
+where ``path`` is the file name or full path for file
+that are not in your "output" directory (a subdirectory of your work
+directory called ``output``). . The "skeet_media.txt" example template
+shows how to do this.
+
+The image could be from a web cam, or for a weather forecast it could be
+an icon representing the forecast. To add a weather graph you need to
+make sure the graph is drawn before the tweet is sent. The
+:py:mod:`pywws.regulartasks` module processes graph and text templates
+before doing service uploads, so you can include the graph drawing in
+the same section. For example::
+
+    [hourly]
+    plot = ['skeet.png.xml']
+    text = ['skeet_media.txt']
+    services = [('bluesky', 'skeet_media.txt')]
+
+.. _Bluesky: https://bsky.app/
+
+"""
+
+from __future__ import absolute_import, print_function
+
+import codecs
+from contextlib import contextmanager
+import logging
+import os
+import sys
+
+import atprototools
+
+import pywws.service
+
+__docformat__ = "restructuredtext en"
+service_name = os.path.splitext(os.path.basename(__file__))[0]
+logger = logging.getLogger(__name__)
+
+class ToService(pywws.service.FileService):
+    config = {
+        'handle'      : (None, True, None),
+        'password'    : (None, True, None),
+        }
+    logger = logger
+    service_name = service_name
+
+    def __init__(self, context, check_params=True):
+        super(ToService, self).__init__(context, check_params)
+        # get default character encoding of template output
+        self.encoding = context.params.get(
+            'config', 'template encoding', 'iso-8859-1')
+
+    @contextmanager
+    def session(self):
+        yield atprototools.Session(self.params['handle'], self.params['password'])
+
+    def upload_file(self, session, filename):
+        media=None
+        with codecs.open(filename, 'r', encoding=None) as skeet_file:
+            skeet = skeet_file.read()
+        while skeet.startswith('media'):
+            media_item, skeet = skeet.split('\n', 1)
+            media_item = media_item.split()[1]
+            if not os.path.isabs(media_item):
+                media = os.path.join(self.context.output_dir, media_item)
+        try:
+            session.postBloot(skeet,image_path=media)
+        except Exception as ex:
+            return False, repr(ex)
+        return True, 'OK'
+
+    def register(self):
+        self.check_params('handle', 'password')
+        #not sure what else to put here, or how to get an app password programmatically
+
+if __name__ == "__main__":
+    sys.exit(pywws.service.main(ToService))


### PR DESCRIPTION
Since the demise of Twitter's API I've finally switched to Bluesky and fingured out how to get pywws to talk to it.
I've made use of the atprototools library which provides the interface with the Bluesky API.

There are some points to note:
* I'm not that good a python; I think I've managed to follow the process and match best practice but always open to improvement
* The atprototools only allows for one image with a post, and doesn't allow ALT text for it. I'm hoping that a future version (or perhaps another library) could expand the functionality
* Hashtags in post are supported, but in a really labourious way. As per the lastest guidance (https://docs.bsky.app/docs/advanced-guides/post-richtext#producing-facets) you're supposed to do the leg-work, find the start/end of facets, and then include them alongside the post; why they don't just do this themselves? *shrug*
* The encoding was going wrong with the degrees symbols; I was getting Â° when posting when the text was just °; I tried to find the source of this but just couldn't. I feel like it's double encoding it, hence adding the leading Â. I've set the encodeing to None and this has worked for me, but it doesn't feel right
* The register section is a bit of a lost cause. I've included instructions on how to complete this manually in the upper section. As for the automation of this, I'm afraid that beyond my understanding, and I'm not sure if the API currently supports it.