### PR TITLE
MQTT v2 and SQLite3 updates

### DIFF
--- a/src/pywws/service/mqtt.py
+++ b/src/pywws/service/mqtt.py
@@ -244,8 +244,12 @@ class ToService(pywws.service.LiveDataService):
 
     @contextmanager
     def session(self):
-        session = mosquitto.Client(
-            self.params['client_id'], protocol=mosquitto.MQTTv31)
+        try:
+            session = mosquitto.Client(mosquitto.CallbackAPIVersion.VERSION1,
+                self.params['client_id'], protocol=mosquitto.MQTTv31)
+        except AttributeError:
+            session = mosquitto.Client(
+                self.params['client_id'], protocol=mosquitto.MQTTv31)
         if self.params['password']:
             session.username_pw_set(
                 self.params['user'], self.params['password'])

--- a/src/pywws/sqlite3data.py
+++ b/src/pywws/sqlite3data.py
@@ -85,7 +85,7 @@ import os.path
 from threading import RLock
 from datetime import date, datetime, timedelta
 
-import pytz
+from pywws.timezone import time_zone
 
 from pywws.weatherstation import WSDateTime, WSFloat, WSInt, WSStatus
 
@@ -97,8 +97,8 @@ def _adapt_WSDateTime(dt):
     """
     try:
         ts = int(
-            (dt.replace(tzinfo=pytz.utc)
-            - datetime(1970,1,1,tzinfo=pytz.utc)
+            (dt.replace(tzinfo=time_zone.utc)
+            - datetime(1970,1,1,tzinfo=time_zone.utc)
             ).total_seconds()
         )
     except (OverflowError,OSError):
@@ -128,8 +128,6 @@ def _convert_WSFloat(b):
 def _convert_WSInt(b):
     """Return WSInt for the given input"""
     return WSInt(b)
-
-sqlite3.enable_shared_cache(True)
 
 sqlite3.register_adapter(datetime, _adapt_WSDateTime)
 sqlite3.register_adapter(WSDateTime, _adapt_WSDateTime)


### PR DESCRIPTION
SQLite3 data store no longer requires the deprecated pytz, a long overdue migration, and removal of shared cache mode as the use is discouraged.

Paho MQTT v2 libraries now ship by default in RaspberryPi OS Trixie so we now must specifically opt for v1 callback mode. Migration should still default to native v1 libraries for older installations. v1 callbacks are deprecated but still supported in v2 the v2 library according to these [docs](https://eclipse.dev/paho/files/paho.mqtt.python/html/migrations.html).

In theory, this should resolve issue #116 and maintain backward compatibility, but I cannot exhaustively test this on all past versions.